### PR TITLE
Better Parsing Strategy + KeyID delimiter change + Base32 instead of hex.

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -26,7 +26,7 @@ This document will use the following terms to define data types.
 1. **NUMERIC**: The **NUMERIC** data type is a sequence of integers between 0 and 99999999, inclusive.
 2. **STRING**: The **STRING** data type is a sequence of UTF-8, [NFC Normalized](https://www.unicode.org/faq/normalization.html) characters, up to 255 bytes after encoding.
 3. **HASH**: The **HASH** data type is a sequence of 52 alphanumeric characters containing a base32-encoded hash.
-3. **SIGNATUREBASE32**: The **SIGNATUREBASE32** data type is a sequence of up-to-72 alphanumeric characters containing a base32url-encoded digest.
+3. **SIGNATUREBASE32**: The **SIGNATUREBASE32** data type is a sequence of up-to-102 alphanumeric characters containing a base32url-encoded digest.
 4. **DATE**: a date, in [ISO 8601 (YYYYMMDD) Basic Notation](https://en.wikipedia.org/wiki/ISO_8601). Example: `20200201` is 1 February, 2020.
 5. **SHORTSTRING**: a sequence of US-ASCII characters which is limited to 8 bytes in length.
 6. **SHORTNUMERIC**: a **NUMERIC** with a maximum value of 9.

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -85,7 +85,7 @@ The payload section is designated the **DATA** block and the cryptographic signa
 In the JSON format, blocks and key/value pairs may occur in any order. For example, a JSON document with the **DATA** block after the **SIGNATURE** block is equivalent to a document with the **SIGNATURE** block after the **DATA** block. Similarly, the key/value pairs within a block may appear in any order.
 
 ## The **SIGNATURE** Block
-The signature block contains the hexadecimal ECDSA signature digest of the prepared **DATA** block and a *keyId* referencing the database and public key used to verify the ECDSA signature. In the example below, the public key used to verify the signature is `1a9` in the `cdc` (local key/value) store. The colon character (`:`) is used as a delimiter to separate the key-value store identifier and the key identifier.
+The signature block contains the hexadecimal ECDSA signature digest of the prepared **DATA** block and a *keyId* referencing the database and public key used to verify the ECDSA signature. In the example below, the public key used to verify the signature is `1a9` in the `cdc` (local key/value) store. The period character (`.`) is used as a delimiter to separate the key-value store identifier and the key identifier.
 
 1. *keyId*: **SHORTSTRING**. a string describing the database and index, the url to download the PEM, or the DNS TXT record of the
    public key to be used when verifying the cryptographic signature of the **DATA** block.
@@ -99,7 +99,7 @@ The signature block contains the hexadecimal ECDSA signature digest of the prepa
   "version": 1,
   "data": { ... },
   "signature": {
-    "keyId": "cdc:1a9",
+    "keyId": "1a9.cdc",
     "hex": "3045022100ee898ba22454a92d972bc2573dbdb61b4cddbde9d90b264089d12201c5833e4402205e6c193f608906bdd3b395ead4ddbc602ee3cba08c2fbc5cb95ea9718d68ad2a"
   }
 }
@@ -111,7 +111,7 @@ When data length is a concern, this format may use fewer bytes than JSON. Keys s
 ## URI Schema
 With URI format, payload is organized according to the following URI schema starting with "cred":
 ```
-cred:type:version:signatureHex.keyId?payload
+cred:type:version:signature:keyId:payload
 ```
 The payload should be represented as a series of **uppercased**, **percent-encoded** values delimited by the slash (`/`) character. The serialization order is defined in each type of payload specification and key names are omitted.
 
@@ -119,7 +119,7 @@ The payload should be represented as a series of **uppercased**, **percent-encod
 
 The example below is a valid credential
 ```
-cred:coupon:1:3046022100f82e28019428220d47be9b7dc9a50b4f0e6f9a6c95852a9272827cdbd8cb38d2022100b5d8738178cc1a12b590b25933857d967eb10178c5bbe045d132ec2513ddfa94.cdc:1a9?37/5000/San%20Francisco/1B/Teacher
+cred:coupon:1:3046022100f82e28019428220d47be9b7dc9a50b4f0e6f9a6c95852a9272827cdbd8cb38d2022100b5d8738178cc1a12b590b25933857d967eb10178c5bbe045d132ec2513ddfa94:1a9.cdc:37/5000/San%20Francisco/1B/Teacher
 ```
 
 ## Percent Encoding Payload Fields
@@ -144,11 +144,11 @@ Unfilled fields MUST be submitted as empty between slash (`/`) characters. Only 
 ## Which Characters Need Encoding?
 
 The columns in the table below indicate encoding requirements for each
-representable character. Any non-listed characters MUST be percent encoded. The
+representable character. Any non-listed characters MUST be percent-encoded. The
 "URI Requires" column indicates whether the URI format rules (RFC 2396) requires encoding the character.
 The "Alphanumeric QR Requires" column indicates whether the character is missing from the
 Alphanumeric QR character set (thus, requiring encoding). The "Must Encode?" column indicates whether this
-specification requires percent encoding of the character. The "Output Value"
+specification requires percent-encoding of the character. The "Output Value"
 column indicates the expected output from processing the listed character.
 
 | Character | URI Requires | Alphanumeric QR Requires | Must Encode? | Output Value |
@@ -232,11 +232,11 @@ for ($i ::= 0; $i < length($payload); $i += 1) do
 end
 
 $payloadString ::= join("/", $payload);
-$signatureHex ::= ecdsaSign($payloadString);
-$base ::= "cred:coupon:" + $version + ":" + $signatureHex + "." + $keyId;
+$signature ::= ecdsaSign($payloadString);
+$base ::= "cred:coupon:" + $version + ":" + $signature + ":" + $keyId;
 $upcasedBase ::= upcase($base);
 
-$uri ::= $upcasedBase + "?" + $payloadString;
+$uri ::= $upcasedBase + ":" + $payloadString;
 ```
 
 # **COUPON** Payload
@@ -263,7 +263,7 @@ Fields in the **serialization** order:
     "indicator": "Teacher"
   },
   "signature": {
-    "keyId": "cdc:1a9",
+    "keyId": "1a9.cdc",
     "hex": "3045022100ee898ba22454a92d972bc2573dbdb61b4cddbde9d90b264089d12201c5833e4402205e6c193f608906bdd3b395ead4ddbc602ee3cba08c2fbc5cb95ea9718d68ad2a"
   }
 }
@@ -328,7 +328,7 @@ the string `28+14`.
     "dose": 500
   },
   "signature": {
-    "keyId": "cdc:1a9",
+    "keyId": "1a9.cdc",
     "hex": "3046022100fdff876e90286a0b06c4181d78b23d5b960cb60a53a94f946b12bbb321ec24c6022100c22e739dfd59b37f8eddc915475190e12f8c10a632560afaab68e498c12de2ac"
   }
 }
@@ -353,7 +353,7 @@ Fields in the **serialization** order:
     "passkey": "d9116bbdf7e33414b23ce81b2d4b9079a111d7119be010a5dcde68a1e5414d2d"
   },
   "signature": {
-    "keyId": "cdc:1a9",
+    "keyId": "1a9.cdc",
     "hex": "304402203210213d35685bed9c9df83218839d0ea1f10cf50e64b0a3a8fbdcfbde0a6bf00220494bfc07481d285d00de9cf5b30a81754314b9cfccb6651597c733cc680ca588"
   }
 }
@@ -395,7 +395,7 @@ hash(“${name}\x1E${dob}\x1E${phone}\x1E${salt}”) == hash(“JANE DOE\x1E1901
     "phone": "16170000000",
   },
   "signature": {
-    "keyId": "cdc:1a9",
+    "keyId": "1a9.cdc",
     "hex": "3046022100f82e28019428220d47be9b7dc9a50b4f0e6f9a6c95852a9272827cdbd8cb38d2022100b5d8738178cc1a12b590b25933857d967eb10178c5bbe045d132ec2513ddfa94"
   }
 }

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -57,15 +57,19 @@ All fields (keys as well as values) are case-insensitive in both JSON and URI fo
 
 For clarity and ease of reading, examples in this document are given in mixed case. 
 
-## Encoding
+## Payload Percent Encoding
 
-Percent encoding is used to address QR code character set limitations. 
+Percent encoding of the payload is used to address QR code character set limitations, while supporting the URI spec. 
 
-## Signing and Hashing Constraints
+## Base32URL Encoding
 
-* Cryptographic signatures and hashes **MUST** be calculated against **uppercased**, **percent encoded** versions of the underlying payload.
-* Data to be used for hashes is serialized in the specified order this document describes. 
-* Signatures should be calculated against the final format and order encoded in the payload field of the QR to permit signature verification before any decoding.
+A version of the Base32 ([RFC4648](https://tools.ietf.org/html/rfc4648)) without padding (Base32URL) is used to encode hashes and signatures. The removal of the padding is due to the fact that `=` is not a supported character on both URI and alphanumeric QR codes. 
+
+## Signing and Hashing
+
+Data to be used for signing and hashes is serialized in the specified order this document describes. Cryptographic signatures and hashes **MUST** be calculated against **uppercased**, **percent encoded** versions of the underlying payload, as they appear in the final URI. This permits signature verification before any decoding. 
+
+The cryptographic tools must sign and verify a SHA256 hash of the UTF-8 byte array of the **uppercased**, **percent-encoded** payload. The resulting signature in Distinguished Encoding Rules (DER) format must be then encoded in Base32 ([RFC4648](https://tools.ietf.org/html/rfc4648)), removed the added padding (`=`) and added to the URI.
 
 # The JSON Format
 
@@ -140,12 +144,6 @@ Unfilled fields MUST be submitted as empty between slash (`/`) characters. Only 
 | `1` | `2` |     | `1/2`   |
 | `1` | `2` | `3` | `1/2/3` |
 | `1` |     | `3` | `1//3`  |
-
-## Signing Signature 
-
-The cryptographic tool must sign a SHA256 hash of the UTF-8 byte array of the **uppercased**, **percent-encoded** payload, as found in the URI. Some libraries already perform this hashing and encoding operation, others require developer to force a non-default hash function. 
-
-The resulting signature in Distinguished Encoding Rules (DER) format must be then encoded in Base32 ([RFC4648](https://tools.ietf.org/html/rfc4648)), removed the added padding (`=`) and added to the URI.
 
 ## Which Characters Need Encoding?
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -26,7 +26,7 @@ This document will use the following terms to define data types.
 1. **NUMERIC**: The **NUMERIC** data type is a sequence of integers between 0 and 99999999, inclusive.
 2. **STRING**: The **STRING** data type is a sequence of UTF-8, [NFC Normalized](https://www.unicode.org/faq/normalization.html) characters, up to 255 bytes after encoding.
 3. **HASH**: The **HASH** data type is a sequence of 52 alphanumeric characters containing a base32-encoded hash.
-3. **SIGNATUREBASE32**: The **SIGNATUREBASE32** data type is a sequence of up-to-72 alphanumeric characters containing a base32-encoded digest.
+3. **SIGNATUREBASE32**: The **SIGNATUREBASE32** data type is a sequence of up-to-72 alphanumeric characters containing a base32url-encoded digest.
 4. **DATE**: a date, in [ISO 8601 (YYYYMMDD) Basic Notation](https://en.wikipedia.org/wiki/ISO_8601). Example: `20200201` is 1 February, 2020.
 5. **SHORTSTRING**: a sequence of US-ASCII characters which is limited to 8 bytes in length.
 6. **SHORTNUMERIC**: a **NUMERIC** with a maximum value of 9.
@@ -59,7 +59,7 @@ For clarity and ease of reading, examples in this document are given in mixed ca
 
 ## Payload Percent Encoding
 
-Percent encoding of the payload is used to address QR code character set limitations, while supporting the URI spec. 
+Percent encoding of the upcased payload is used to address QR code character set limitations, while supporting the URI spec. 
 
 ## Base32URL Encoding
 
@@ -89,11 +89,11 @@ The payload section is designated the **DATA** block and the cryptographic signa
 In the JSON format, blocks and key/value pairs may occur in any order. For example, a JSON document with the **DATA** block after the **SIGNATURE** block is equivalent to a document with the **SIGNATURE** block after the **DATA** block. Similarly, the key/value pairs within a block may appear in any order.
 
 ## The **SIGNATURE** Block
-The signature block contains the base32 ECDSA signature digest of the prepared **DATA** block and a *keyId* referencing the database and public key used to verify the ECDSA signature. In the example below, the public key used to verify the signature is `1a9` in the `cdc` (local key/value) store. The period character (`.`) is used as a delimiter to separate the key-value store identifier and the key identifier.
+The signature block contains the Base32URL ECDSA signature digest of the prepared **DATA** block and a *keyId* referencing the database and public key used to verify the ECDSA signature. In the example below, the public key used to verify the signature is `1a9` in the `cdc` (local key/value) store. The period character (`.`) is used as a delimiter to separate the key-value store identifier and the key identifier.
 
 1. *keyId*: **SHORTSTRING**. a string describing the database and index, the url to download the PEM, or the DNS TXT record of the
    public key to be used when verifying the cryptographic signature of the **DATA** block.
-2. *base32*: **SIGNATUREBASE32**. The Base32-encoded SHA256 digest ECDSA signature of the
+2. *base32*: **SIGNATUREBASE32**. The Base32URL-encoded SHA256 digest ECDSA signature of the
    **DATA** block, calculated according to the rules above.
 
 ### JSON Example
@@ -263,21 +263,21 @@ for ($i ::= 0; $i < length($payload); $i += 1) do
 end
 ```
 
-## Pseudo-Code describing adding and remove Base32 Padding
+## Pseudo-Code describing Base32 to Base32URL Mapping
 
 To remove padding from Base32-encoded strings do: 
 ```bash
-$base32NoPad ::= $base32Str.replaceAll("=", "");
+$base32URL ::= $base32.replaceAll("=", "");
 ```
 
 To add padding back to Base32-encoded strings do:
 ```bash
 switch ($base32NoPad.length % 8) {
-    case 2: $base32Str ::= $base32NoPad + "======"; break;
-    case 4: $base32Str ::= $base32NoPad + "====";  break;
-    case 5: $base32Str ::= $base32NoPad + "==="; break;
-    case 7: $base32Str ::= $base32NoPad + "="; break;
-    default: $base32Str ::= $base32NoPad;
+    case 2: $base32 ::= $base32URL + "======"; break;
+    case 4: $base32 ::= $base32URL + "====";  break;
+    case 5: $base32 ::= $base32URL + "==="; break;
+    case 7: $base32 ::= $base32URL + "="; break;
+    default: $base32 ::= $base32URL;
 }
 ```   
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -45,7 +45,7 @@ The **type** field defines the payload type (`COUPON`, `PASSKEY`, `BADGE` or `ST
 The reference to the **public** key can be: 
 1. a FQDN to a DNS TXT Record containing the key for download (TODO: Need to specify the format of the TXT Record).
 1. a URL address to download keys from. 
-1. a database and key ID to facilitate trusted lists of issuers (TODO: Need to specify this keyId format). 
+1. a database and key ID to facilitate trusted lists of issuers (TODO: Need to specify this keyId database format). 
 
 For signature verification, devices should maintain an indexed local key-value stores of approved public keys in PEM format. 
 
@@ -101,7 +101,7 @@ The signature block contains the Base32URL ECDSA signature digest of the prepare
 {
   "type": "coupon",
   "version": 1,
-  "data": { ... },
+  "data": { },
   "signature": {
     "keyId": "1a9.cdc",
     "base32": "GBDAEIIA42QDQ5BDUUXVMSQ4VIMMA7RETIZSXB573OL24M4L67LYB24CZYVQEIIA2EZ5W2QXLR7LUSLQW6MLAFV3N7OTT3BDAZCNCRMYBMUYC6WMXMNQ"


### PR DESCRIPTION
Only use `:` to separate blocks `cred:type:version:Signature:PubKey:Payload`
- it doesn’t make sense to use `?` to separate the key from the payload, since the payload is not a query string anymore
- makes it easy to parse the URI into variables by simply doing a split on `:`.

Change the keyID spec from `cdc:id` to `id.cdc`
- following a domain name standard: `specific.to.broad`
- avoiding splitting the key and id when parsing by `:`

Changing from Hex encoding to Base32 encoding